### PR TITLE
Support for DynamicAxis Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dtkit.model.version>0.16</dtkit.model.version>
         <dtkit.util.version>0.16</dtkit.util.version>
         <java2html.version>5.0</java2html.version>
-        <junit.version>4.8.2</junit.version>
+        <junit.version>4.11</junit.version>
         <mockito.version>1.8.5</mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>

--- a/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
@@ -31,6 +31,8 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.matrix.Combination;
+import hudson.matrix.MatrixConfiguration;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
@@ -209,7 +211,10 @@ public class KloBuilder extends Builder {
         }
 
         //AM : changing lastBuildNo
-        String lastBuildNo = "build_ci_" + build.getId();
+		//AS : Support for DynamicAxis Plugin
+		MatrixConfiguration matrix = (MatrixConfiguration) build.getProject();
+        Combination currentAxes = matrix.getCombination();
+        String lastBuildNo = "build_ci_" + build.getId() + "_" + currentAxes.digest();
         lastBuildNo = lastBuildNo.replaceAll("[^a-zA-Z0-9_]", "");
 
         //AM : Since version 0.2.1, fileOut doesn't exist anymore

--- a/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
@@ -211,10 +211,14 @@ public class KloBuilder extends Builder {
         }
 
         //AM : changing lastBuildNo
-		//AS : Support for DynamicAxis Plugin
-		MatrixConfiguration matrix = (MatrixConfiguration) build.getProject();
-        Combination currentAxes = matrix.getCombination();
-        String lastBuildNo = "build_ci_" + build.getId() + "_" + currentAxes.digest();
+        //AS : Support for DynamicAxis Plugin
+		String suffix = "";
+        if (build.getProject().getClass().getName().equals(MatrixConfiguration.class.getName())) {
+            MatrixConfiguration matrix = (MatrixConfiguration) build.getProject();
+            Combination currentAxes = matrix.getCombination();
+            suffix = "_" + currentAxes.digest();
+        }
+        String lastBuildNo = "build_ci_" + build.getId() + suffix;
         lastBuildNo = lastBuildNo.replaceAll("[^a-zA-Z0-9_]", "");
 
         //AM : Since version 0.2.1, fileOut doesn't exist anymore

--- a/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/klocwork/KloBuilder.java
@@ -51,6 +51,7 @@ import java.util.logging.Logger;
 public class KloBuilder extends Builder {
 
     private String projectName;
+    private String convertedProjectName;
     private String kloName;
 
     private int buildUsing;
@@ -212,7 +213,7 @@ public class KloBuilder extends Builder {
 
         //AM : changing lastBuildNo
         //AS : Support for DynamicAxis Plugin
-		String suffix = "";
+        String suffix = "";
         if (build.getProject().getClass().getName().equals(MatrixConfiguration.class.getName())) {
             MatrixConfiguration matrix = (MatrixConfiguration) build.getProject();
             Combination currentAxes = matrix.getCombination();
@@ -258,7 +259,10 @@ public class KloBuilder extends Builder {
             }//for
         }//else
 
-        argsKwbuildproject.add("--project", UserAxisConverter.AxeConverter(build, projectName), "--tables-directory",
+        // AS : Enforce 64 byte limit for project name.
+        convertedProjectName = UserAxisConverter.AxeConverter(build, projectName);
+        convertedProjectName = convertedProjectName.substring(0, Math.min(convertedProjectName.length(), 64));
+        argsKwbuildproject.add("--project", convertedProjectName, "--tables-directory",
                 /*proj.getModuleRoot()*/ kloTables, "--host", currentInstall.getProjectHost(), "--port", currentInstall.getProjectPort(),
                 (currentInstall.getUseSSL() ? "--ssl" : null), //New in v1.15
                 "--license-host", currentInstall.getLicenseHost(), "--license-port",
@@ -302,7 +306,8 @@ public class KloBuilder extends Builder {
         argsKwadmin.add("--host", currentInstall.getProjectHost(), "--port", currentInstall.getProjectPort(),
                 (currentInstall.getUseSSL() ? "--ssl" : null), //New in v1.15
                 "load",
-                UserAxisConverter.AxeConverter(build, projectName),/*proj.getModuleRoot()*/ kloTables, "--name", lastBuildNo);
+                // AS : Enforce 64 byte limit for project name.
+                convertedProjectName,/*proj.getModuleRoot()*/ kloTables, "--name", lastBuildNo);
 
         //Building process
         ArgumentListBuilder argsBuild = new ArgumentListBuilder();
@@ -375,7 +380,8 @@ public class KloBuilder extends Builder {
 
             //AM : changing the way to add the arguments
             argsKwinspectreport.add(execKwinspectreport);
-            argsKwinspectreport.add("--project", UserAxisConverter.AxeConverter(build, projectName), "--build", lastBuildNo, "--xml",/*proj.getModuleRoot()*/build.getWorkspace().getRemote() +
+            // AS : Enforce 64 byte limit for project name.
+            argsKwinspectreport.add("--project", convertedProjectName, "--build", lastBuildNo, "--xml",/*proj.getModuleRoot()*/build.getWorkspace().getRemote() +
                             FS +/*"kloXML"+FS+build.getId()+".xml"*/"klocwork_result.xml", "--host", currentInstall.getProjectHost(), "--port", currentInstall.getProjectPort(),
                     (currentInstall.getUseSSL() ? "--ssl" : null), //New in v1.15
                     "--license-host", currentInstall.getLicenseHost(), "--license-port", currentInstall.getLicensePort()
@@ -396,7 +402,8 @@ public class KloBuilder extends Builder {
 
 
             // Finally store currentInstall and projectName for publisher to use
-            build.addAction(new KloBuildInfo(build, currentInstall, UserAxisConverter.AxeConverter(build, projectName)));
+            // AS : Enforce 64 byte limit for project name.
+            build.addAction(new KloBuildInfo(build, currentInstall, convertedProjectName));
 
             //New in 1.15: allow user to delete the klotable after all analysis.
             if (deleteTable && new File(kloTables).exists()) {


### PR DESCRIPTION
Using DynamicAxis Plugin, builds fail with a build already exist error, due to the same build name being supplied for each configuration. This commit adds the digest of the axes combination to the build name. Reason for digest is to stay within the name length requirement.

During 'mvn install', I saw a bunch of errors that were resolved by following this advice: http://stackoverflow.com/a/29611971/331168
> When using in Maven, update artifact junit:junit from e.g. 4.8.2 to 4.11.